### PR TITLE
Add TOC support

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5,8 +5,7 @@
 
 /* 增强Markdown渲染样式 */
 @theme {
-  --font-bilingual: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif,
-    "Noto Serif SC";
+  --font-bilingual: ui-serif, "Noto Serif SC", Georgia, Cambria, "Times New Roman", Times, serif;
 }
 
 /* 表格样式增强 */
@@ -158,7 +157,7 @@
   @apply p-4 overflow-x-auto m-0 w-full;
   background-color: transparent;
   border: none;
-  color: #000000;
+  color: inherit;
 }
 
 .code-block-container pre code {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -176,3 +176,8 @@
 div#disqus_thread iframe[sandbox] {
   max-height: 0px !important;
 }
+
+/* add margin between paragraphs */
+p + p {
+  margin-top: 5px;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -153,10 +153,12 @@
 }
 
 /* Code block styles */
+
 .code-block-container pre {
   @apply p-4 overflow-x-auto m-0 w-full;
-  background-color: #ffffff;
+  background-color: transparent;
   border: none;
+  color: #000000;
 }
 
 .code-block-container pre code {
@@ -165,7 +167,7 @@
   word-break: normal;
   white-space: pre;
   line-height: 1.5rem;
-  background-color: #ffffff;
+  background-color: transparent;
   padding: 0;
   font-size: 14px;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -180,3 +180,46 @@ div#disqus_thread iframe[sandbox] {
 p + p {
   margin-top: 5px;
 }
+
+
+/* add toc support */
+.toc {
+  background-color: transparent;
+  margin-bottom: 20px;
+  border-radius: 5px;
+}
+
+.toc h2 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  font-size: 1.2em;
+}
+
+.toc ul {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+.toc ul ul {
+  padding-left: 15px; /* Indent sub-levels */
+  font-size: 0.95em;
+}
+
+.toc li {
+  margin-bottom: 5px;
+}
+
+.toc a {
+  text-decoration: none;
+  color: #337ab7; /* Example link color */
+}
+
+.toc a:hover {
+  text-decoration: underline;
+}
+
+/* Specific ID Hugo generates for the TOC nav element */
+#TableOfContents {
+  /* You can add specific styles if needed,
+     but the .toc class provides a good wrapper */
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -183,43 +183,33 @@ p + p {
 
 
 /* add toc support */
-.toc {
-  background-color: transparent;
-  margin-bottom: 20px;
-  border-radius: 5px;
+.toc-sidebar nav#TableOfContents ul {
+  list-style-type: none; /* Or 'decimal' if you configured ordered lists */
+  padding-left: 0;
 }
 
-.toc h2 {
-  margin-top: 0;
-  margin-bottom: 10px;
-  font-size: 1.2em;
+.toc-sidebar nav#TableOfContents ul ul {
+  padding-left: 1rem; /* Indent sub-levels */
+  /* margin-top: 0.25rem; */
 }
 
-.toc ul {
-  padding-left: 20px;
-  margin-bottom: 0;
+.toc-sidebar nav#TableOfContents li {
+  /* margin-bottom: 0.25rem; */
 }
 
-.toc ul ul {
-  padding-left: 15px; /* Indent sub-levels */
-  font-size: 0.95em;
-}
-
-.toc li {
-  margin-bottom: 5px;
-}
-
-.toc a {
+.toc-sidebar nav#TableOfContents li a {
+  @apply text-sm text-gray-600 hover:text-blue-600 block py-1; /* Tailwind for consistency */
   text-decoration: none;
-  color: #337ab7; /* Example link color */
+  transition: color 0.2s ease-in-out;
 }
 
-.toc a:hover {
-  text-decoration: underline;
+.toc-sidebar nav#TableOfContents li a:hover {
+  @apply text-blue-700;
 }
 
-/* Specific ID Hugo generates for the TOC nav element */
-#TableOfContents {
-  /* You can add specific styles if needed,
-     but the .toc class provides a good wrapper */
+/* Optional: Active link styling (would require JavaScript to dynamically add 'active' class) */
+.toc-sidebar nav#TableOfContents li a.active {
+  @apply font-semibold text-blue-700;
+  border-left: 2px solid; /* Example: theme('colors.blue.700'); */
+  padding-left: calc(1rem - 2px); /* Adjust if you have padding on `ul ul` */
 }

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -46,6 +46,15 @@
       </div>
     </header>
 
+    {{ if .TableOfContents }}
+    <div class="p-8 border-b border-gray-100">
+      <aside class="toc bg-gray-50 p-6 rounded-md">
+        <div class="toc-content">
+          {{ .TableOfContents }}
+        </div>
+      </aside>
+    </div>
+    {{ end }}
     <div class="p-8 prose prose-sm sm:prose lg:prose-lg max-w-none">
       {{ .Content }}
     </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -46,15 +46,22 @@
       </div>
     </header>
 
+    {{/* TOC Sidebar - takes remaining space on larger screens */}}
     {{ if .TableOfContents }}
-    <div class="p-8 border-b border-gray-100">
-      <aside class="toc bg-gray-50 p-6 rounded-md">
+    <aside class="lg:w-1/4 w-full lg:mt-0 mt-8">
+      {{/* Sticky container for the TOC */}}
+      {{/* Adjust `top-28` (7rem) as needed to clear your fixed header. Header has `pt-24` (6rem). */}}
+      <div class="sticky top-[calc(6rem+1rem)] {{/* 6rem for header + 1rem margin */}}
+                  p-6 rounded-lg
+                  max-h-[calc(100vh-8rem)] {{/* Limits height and enables scrolling */}}
+                  overflow-y-auto toc-sidebar">
         <div class="toc-content">
           {{ .TableOfContents }}
         </div>
-      </aside>
-    </div>
+      </div>
+    </aside>
     {{ end }}
+
     <div class="p-8 prose prose-sm sm:prose lg:prose-lg max-w-none">
       {{ .Content }}
     </div>


### PR DESCRIPTION
Add TOC support

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

添加对响应式、粘性目录侧边栏的支持，并优化相关的 CSS 样式。

新功能：
- 在内容页面中以响应式、粘性侧边栏渲染 Hugo 目录 (TableOfContents)

增强功能：
- 更新双语字体栈顺序
- 使代码块背景透明并继承文本颜色
- 在段落之间添加一致的顶部边距
- 使用 Tailwind 实用程序设置 TOC 列表、链接、悬停和活动状态的样式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a responsive, sticky Table of Contents sidebar and refine related CSS styles.

New Features:
- Render Hugo TableOfContents in a responsive, sticky sidebar on content pages

Enhancements:
- Update bilingual font stack ordering
- Make code block backgrounds transparent and inherit text color
- Add consistent top margin between paragraphs
- Style TOC list, links, hover, and active states with Tailwind utilities

</details>