### PR TITLE
feat: removed Noto Serif SC

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5,7 +5,7 @@
 
 /* 增强Markdown渲染样式 */
 @theme {
-  --font-bilingual: ui-serif, "Noto Serif SC", Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-bilingual: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
 }
 
 /* 表格样式增强 */


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强：
- 从 main.css 中的 --font-bilingual CSS 变量中移除 "Noto Serif SC" 后备字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove "Noto Serif SC" fallback from the --font-bilingual CSS variable in main.css

</details>