### PR TITLE
[codex] Fix light mode color scheme

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,8 @@
 <style>
   /* Minimal pre-CSS paint to avoid white flash on dark */
   html.dark, html.dark body { background-color: #0b1220; }
-  html { color-scheme: light dark; }
+  html { color-scheme: light; }
+  html.dark { color-scheme: dark; }
   </style>
 
 <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary

- bind the browser `color-scheme` to the theme's `.dark` class
- force the browser UI defaults to use the light scheme whenever the site is in light mode
- preserve the existing dark-mode behavior and no-flash initialization

## Root cause

The document always declared `color-scheme: light dark`. When the operating system preferred dark mode but the user explicitly selected the site's light mode, Chromium still chose dark browser defaults. Unstyled text therefore inherited white while the page background was light.

## User impact

Light mode now renders dark default text even when Edge, Chrome, or the operating system prefers dark mode.

## Validation

- Hugo development build completed successfully (59 EN pages, 7 ZH pages)
- Chrome 151 browser regression matrix passed for all four system/site light and dark combinations
- verified the system-dark → site-light toggle changes the computed scheme to `light` and the homepage welcome text to `rgb(0, 0, 0)`
- `git diff --check` passed

Fixes #8

## Summary by Sourcery

Bug 修复：
- 解决当系统或浏览器偏好深色模式时，在浅色模式下默认文本颜色不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect default text color in light mode when the system or browser prefers dark mode.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug 修复：
- 解决当系统或浏览器偏好深色模式时，在浅色模式下默认文本颜色不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect default text color in light mode when the system or browser prefers dark mode.

</details>

</details>